### PR TITLE
Refactor to use app level state and getContext to access sleep store

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,10 +1,36 @@
 <script>
+  import { setContext } from "svelte";
+
+  import {
+    createTimerStoreWithSummary,
+    timerContextKey,
+    timerSumContextKey,
+  } from "./stores/timers";
+
   import Sleep from "./Sleep.svelte";
+
+  export let name = "World";
+
+  // We create the timer tracks in the main app component, so that they will be available for
+  // the whole app. We put this here instead of in the store file because we want flexibilty in how
+  // we initialize and configure stores.
+  let [timerTrack, timerSummary] = createTimerStoreWithSummary([
+    /* We could load initial data and put it here */
+  ]);
+
+  // The context api allows us to access this data from any decendant component without needing to drill
+  // props all the way down. This is effectively 'App global'
+  // The motivation here is that we might want to do something like a summary dashboard, which would need
+  // access to this data.
+  setContext(timerContextKey, timerTrack);
+  setContext(timerSumContextKey, timerSummary);
+
+  // some simple app state for primative tabs
   let currentTab = "naps";
 </script>
 
 <main>
-  <h1>Hello Kiva!</h1>
+  <h1>Hello {name}!</h1>
   <div class="tabs">
     <span on:click={() => (currentTab = "diapers")}>Diapers</span>
     <span on:click={() => (currentTab = "feeds")}>Feeds</span>

--- a/src/Sleep.svelte
+++ b/src/Sleep.svelte
@@ -1,7 +1,9 @@
 <script>
-  import { onDestroy } from "svelte";
+  import { onDestroy, getContext } from "svelte";
 
-  import { sleepSummary, sleepTracker, STATES } from "./stores/sleeps";
+  import { timerContextKey, timerSumContextKey, STATES } from "./stores/timers";
+  const sleepTracker = getContext(timerContextKey);
+  const sleepSummary = getContext(timerSumContextKey);
 
   function formatTimer(duration) {
     let hours = Math.floor(duration / 3600000);

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import App from './App.svelte';
 const app = new App({
 	target: document.body,
 	props: {
-		name: 'world'
+		name: 'Kiva'
 	}
 });
 

--- a/src/stores/mergeSum.js
+++ b/src/stores/mergeSum.js
@@ -1,0 +1,9 @@
+import { derived } from 'svelte/store';
+
+export function deriveMergeSummary(tracker) {
+    return derived(tracker, $track => $track.reduce((acc, curr) => {
+        // We reduce over the track, placing items into the Map by key, merging when an item
+        // has a previously used key. This combines the START and STOP records that match.
+        return acc.set(curr.key, acc.has(curr.key) ? {...acc.get(curr.key), ...curr} : curr)
+    }, new Map()))
+}

--- a/src/stores/timers.js
+++ b/src/stores/timers.js
@@ -1,5 +1,5 @@
 /*
-    The sleeps store is an append only store of timer records.
+    The timers store is an append only store of timer records.
 
     There are two types of records that can be represented, START and STOP. Each of these carries a timestamp for when it occurred.
     When a START record is created, it is assigned a key which should be used to create a corresponding STOP record.
@@ -7,9 +7,19 @@
 
     This file also contains a derived store that produces a summary map of the records. This is
     done by merging the record object with matching keys, and placing them into a Map.
+
+    Note that these are factory methods, and no actual store instance is created.
 */
 
-import { writable, derived } from 'svelte/store';
+import { writable } from 'svelte/store';
+import { deriveMergeSummary } from './mergeSum';
+
+// These are unique keys for finding the timer store in a component context.
+// Since the timer track has the ability to run multiple timers concurrently,
+// we feel pretty ok with only supplying one key. If you do find a need to have
+// multiple timer tracks in one context, you'll have to create your own keys.
+export const timerContextKey = Symbol('Timer context key');
+export const timerSumContextKey = Symbol('Timer Summary context key');
 
 export const STATES = {
     START: 'start',
@@ -39,10 +49,14 @@ function createStop(stop, key) {
     }
 }
 
-function createTrack() {
+export function createTimerStore(init = []) {
     // Start with the stock writable from svelte
-	const { subscribe, set, update } = writable([]);
+	const { subscribe, set, update } = writable(init);
 
+    // create the action interface, much like a reducer.
+    // In this case, we have three additional methods, and we
+    // hide the general 'update' and 'set' methods.
+    // 'subscribe' must be forwarded for this to work as a store.
 	return {
 		subscribe,
         start: () => {
@@ -55,10 +69,9 @@ function createTrack() {
 	};
 }
 
-export const sleepTracker = createTrack();
-
-export const sleepSummary = derived(sleepTracker, $track => $track.reduce((acc, curr) => {
-    // We reduce over the track, placing items into the Map by key, merging when an item
-    // has a previously used key. This combines the START and STOP records that match.
-    return acc.set(curr.key, acc.has(curr.key) ? {...acc.get(curr.key), ...curr} : curr)
-}, new Map()))
+// a factory for getting a store track and a summary at the same time
+export function createTimerStoreWithSummary(init = []) {
+    const track = createTimerStore(init);
+    const sum = deriveMergeSummary(track);
+    return [track, sum];
+}


### PR DESCRIPTION
### Summary
These changes should produce no changes to functionality, and very few changes to the compiled result. What this does do is change how the code is accessed, and where the data is stored.

### Motivation
Following the examples for stores from the Svelte tutorial, I had previously instantiated the store data in the store module file itself. This felt pretty bad, since it generally makes configuration (especially async config) very difficult. 
This change follows a pattern I have used before with React, which is to instantiate the "global" store in the top level App component, and then expose the data using a Context. Consumers of the store then acquire access by importing the context key only, and the actual data is stored at the App component scope. (In React, I have done this with `useReducer` and `useContext` hooks, and this is very similar)
This pattern also allows for much simpler testing, as the store is now injectable through the Context api.

In addition, this let me try out the `setContext` and `getContext` :)